### PR TITLE
Add mkdocs documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -816,3 +816,20 @@ To ensure fast, reliable, and reproducible font discovery for LuaLaTeX and XeLaT
 ## Library Functions
 
 The following utility functions are available in the `lib/`
+
+## Documentation
+
+The docs are written in Markdown under `docs/` and rendered with [mkdocs](https://www.mkdocs.org/).
+
+Build them with:
+
+```bash
+nix build .#documentation
+```
+
+For a live preview while editing, run:
+
+```bash
+nix run .#watch-documentation
+```
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,14 @@
+# Welcome to latex-utils
+
+latex-utils is a Nix flake that builds LaTeX documents in reproducible environments.
+
+## Guides
+
+- [Development Shells](user/devshells.md)
+- [IDE Integration](user/ide-integration.md)
+- [TeX Live Integration](user/texlive-integration.md)
+- [Library Reference](user/library.md)
+- [Unit Testing](user/unit-testing.md)
+- [Consumer Flake Example](user/consumer-flake-example.md)
+- [Example Module Packages](user/example-module-packages.nix)
+- [Comprehensive Example](user/comprehensive-example.nix)

--- a/docs/internal/AGENT_CHANGELOG.md
+++ b/docs/internal/AGENT_CHANGELOG.md
@@ -1,3 +1,51 @@
+Timestamp: 2025-06-07T17:54:13Z
+Agent: Claude 3.5 Sonnet
+
+**DOCUMENTATION BUILD CONFIGURATION FIX**
+
+Successfully resolved build errors with `nix build .#documentation` by correcting the mkdocs-flake configuration mismatch between the flake configuration and mkdocs.yml file location.
+
+**Problem Identified:**
+- **Build Error**: `nix build .#documentation` was failing with "Config file 'mkdocs.yml' does not exist"
+- **Root Cause**: Mismatch between flake configuration (`documentation.mkdocs-root = ./docs;`) and actual mkdocs.yml location (repository root)
+- **mkdocs-flake Behavior**: The mkdocs-flake module looks for mkdocs.yml in the directory specified by `mkdocs-root`
+
+**Investigation Process:**
+- **Commit Analysis**: Examined recent commits on branch `codex/investigate-mkdocs-for-user-documentation`
+- **Configuration Review**: Found mkdocs.yml in repository root but flake pointing to `./docs` directory
+- **mkdocs-flake Documentation**: Researched proper configuration patterns for mkdocs-flake integration
+- **MkDocs Constraints**: Discovered MkDocs requirement that `docs_dir` cannot be the same directory as mkdocs.yml
+
+**Solution Implemented:**
+- **Flake Configuration**: Changed `documentation.mkdocs-root = ./docs;` to `documentation.mkdocs-root = ./.;` in flake.nix
+- **File Structure**: Kept mkdocs.yml in repository root with `docs_dir: docs` configuration
+- **Proper Alignment**: mkdocs-flake now correctly finds mkdocs.yml in repository root and uses docs/ as content directory
+
+**Files Affected:**
+- Modified: `flake.nix` (updated documentation.mkdocs-root configuration)
+- Verified: `mkdocs.yml` (confirmed proper docs_dir configuration)
+
+**Testing Results:**
+- **Before**: `nix build .#documentation` failed with config file not found error
+- **After**: `nix build .#documentation` succeeds and generates complete static website
+- **Output Verification**: Built documentation includes index.html, user guide pages, search functionality, and all assets
+- **Watch Mode**: `nix run .#watch-documentation` command also available and functional
+
+**Architecture Alignment:**
+- **mkdocs-flake Integration**: Follows standard mkdocs-flake patterns with mkdocs.yml in project root
+- **Documentation Structure**: Maintains clean separation between configuration (root) and content (docs/)
+- **Flake Outputs**: Properly exposes both `packages.documentation` and `apps.watch-documentation`
+
+**Benefits Achieved:**
+- **Working Documentation Build**: Developers can now build documentation with `nix build .#documentation`
+- **Live Development**: `nix run .#watch-documentation` enables live documentation editing
+- **CI/CD Ready**: Documentation build can be integrated into automated workflows
+- **Complete Static Site**: Generated output includes all necessary files for web deployment
+
+This fix enables the documentation workflow that was integrated in the recent mkdocs commits, making the documentation system fully functional for both development and deployment scenarios.
+
+---
+
 Timestamp: 2025-06-05T02:28:20Z
 Agent: Claude 3.5 Sonnet
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: latex-utils
 repo_url: https://github.com/jmmaloney4/latex-utils
-docs_dir: docs
+docs_dir: .
 nav:
   - Home: index.md
   - User Guide:

--- a/flake.lock
+++ b/flake.lock
@@ -37,6 +37,27 @@
     "flake-parts_2": {
       "inputs": {
         "nixpkgs-lib": [
+          "mkdocs-flake",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1743550720,
+        "narHash": "sha256-hIshGgKZCgWh6AYJpJmRgFdR3WUbkY04o82X05xqQiY=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "c621e8422220273271f52058f618c94e405bb0f5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-parts_3": {
+      "inputs": {
+        "nixpkgs-lib": [
           "nix-unit",
           "nixpkgs"
         ]
@@ -67,6 +88,24 @@
       "original": {
         "owner": "srid",
         "repo": "flake-root",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1726560853,
+        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
         "type": "github"
       }
     },
@@ -126,7 +165,52 @@
         "type": "github"
       }
     },
+    "mkdocs-flake": {
+      "inputs": {
+        "flake-parts": "flake-parts_2",
+        "nixpkgs": "nixpkgs_2",
+        "poetry2nix": "poetry2nix",
+        "pyproject-build-systems": "pyproject-build-systems",
+        "pyproject-nix": "pyproject-nix",
+        "uv2nix": "uv2nix"
+      },
+      "locked": {
+        "lastModified": 1748072100,
+        "narHash": "sha256-nHkJqIQ7efbi54oz2HDLk7npLtAXikz4Yxhv49Ocg5w=",
+        "owner": "applicative-systems",
+        "repo": "mkdocs-flake",
+        "rev": "9be2e32e61fcde17620ccd7b5e1e82041556a7e7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "applicative-systems",
+        "repo": "mkdocs-flake",
+        "type": "github"
+      }
+    },
     "nix-github-actions": {
+      "inputs": {
+        "nixpkgs": [
+          "mkdocs-flake",
+          "poetry2nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1729742964,
+        "narHash": "sha256-B4mzTcQ0FZHdpeWcpDYPERtyjJd/NIuaQ9+BV1h+MpA=",
+        "owner": "nix-community",
+        "repo": "nix-github-actions",
+        "rev": "e04df33f62cdcf93d73e9a04142464753a16db67",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nix-github-actions",
+        "type": "github"
+      }
+    },
+    "nix-github-actions_2": {
       "inputs": {
         "nixpkgs": [
           "nix-unit",
@@ -149,10 +233,10 @@
     },
     "nix-unit": {
       "inputs": {
-        "flake-parts": "flake-parts_2",
-        "nix-github-actions": "nix-github-actions",
-        "nixpkgs": "nixpkgs_2",
-        "treefmt-nix": "treefmt-nix"
+        "flake-parts": "flake-parts_3",
+        "nix-github-actions": "nix-github-actions_2",
+        "nixpkgs": "nixpkgs_3",
+        "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
         "lastModified": 1745514172,
@@ -201,6 +285,22 @@
     },
     "nixpkgs_2": {
       "locked": {
+        "lastModified": 1747744144,
+        "narHash": "sha256-W7lqHp0qZiENCDwUZ5EX/lNhxjMdNapFnbErcbnP11Q=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "2795c506fe8fb7b03c36ccb51f75b6df0ab2553f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_3": {
+      "locked": {
         "lastModified": 1733376361,
         "narHash": "sha256-aLJxoTDDSqB+/3orsulE6/qdlX6MzDLIITLZqdgMpqo=",
         "owner": "NixOS",
@@ -215,7 +315,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_3": {
+    "nixpkgs_4": {
       "locked": {
         "lastModified": 1748693115,
         "narHash": "sha256-StSrWhklmDuXT93yc3GrTlb0cKSS0agTAxMGjLKAsY8=",
@@ -231,7 +331,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_4": {
+    "nixpkgs_5": {
       "locked": {
         "lastModified": 1747958103,
         "narHash": "sha256-qmmFCrfBwSHoWw7cVK4Aj+fns+c54EBP8cGqp/yK410=",
@@ -247,16 +347,92 @@
         "type": "github"
       }
     },
+    "poetry2nix": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nix-github-actions": "nix-github-actions",
+        "nixpkgs": [
+          "mkdocs-flake",
+          "nixpkgs"
+        ],
+        "systems": "systems_2",
+        "treefmt-nix": "treefmt-nix"
+      },
+      "locked": {
+        "lastModified": 1743690424,
+        "narHash": "sha256-cX98bUuKuihOaRp8dNV1Mq7u6/CQZWTPth2IJPATBXc=",
+        "owner": "nix-community",
+        "repo": "poetry2nix",
+        "rev": "ce2369db77f45688172384bbeb962bc6c2ea6f94",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "poetry2nix",
+        "type": "github"
+      }
+    },
+    "pyproject-build-systems": {
+      "inputs": {
+        "nixpkgs": [
+          "mkdocs-flake",
+          "nixpkgs"
+        ],
+        "pyproject-nix": [
+          "mkdocs-flake",
+          "pyproject-nix"
+        ],
+        "uv2nix": [
+          "mkdocs-flake",
+          "uv2nix"
+        ]
+      },
+      "locked": {
+        "lastModified": 1744599653,
+        "narHash": "sha256-nysSwVVjG4hKoOjhjvE6U5lIKA8sEr1d1QzEfZsannU=",
+        "owner": "pyproject-nix",
+        "repo": "build-system-pkgs",
+        "rev": "7dba6dbc73120e15b558754c26024f6c93015dd7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pyproject-nix",
+        "repo": "build-system-pkgs",
+        "type": "github"
+      }
+    },
+    "pyproject-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "mkdocs-flake",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1746540146,
+        "narHash": "sha256-QxdHGNpbicIrw5t6U3x+ZxeY/7IEJ6lYbvsjXmcxFIM=",
+        "owner": "pyproject-nix",
+        "repo": "pyproject.nix",
+        "rev": "e09c10c24ebb955125fda449939bfba664c467fd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pyproject-nix",
+        "repo": "pyproject.nix",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "flake-parts": "flake-parts",
         "flake-root": "flake-root",
         "git-hooks-nix": "git-hooks-nix",
         "mission-control": "mission-control",
+        "mkdocs-flake": "mkdocs-flake",
         "nix-unit": "nix-unit",
-        "nixpkgs": "nixpkgs_3",
-        "systems": "systems",
-        "treefmt-nix": "treefmt-nix_2"
+        "nixpkgs": "nixpkgs_4",
+        "systems": "systems_3",
+        "treefmt-nix": "treefmt-nix_3"
       }
     },
     "systems": {
@@ -274,7 +450,59 @@
         "type": "github"
       }
     },
+    "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_3": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
     "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "mkdocs-flake",
+          "poetry2nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1730120726,
+        "narHash": "sha256-LqHYIxMrl/1p3/kvm2ir925tZ8DkI0KA10djk8wecSk=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "9ef337e492a5555d8e17a51c911ff1f02635be15",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
+    "treefmt-nix_2": {
       "inputs": {
         "nixpkgs": [
           "nix-unit",
@@ -295,9 +523,9 @@
         "type": "github"
       }
     },
-    "treefmt-nix_2": {
+    "treefmt-nix_3": {
       "inputs": {
-        "nixpkgs": "nixpkgs_4"
+        "nixpkgs": "nixpkgs_5"
       },
       "locked": {
         "lastModified": 1748243702,
@@ -310,6 +538,31 @@
       "original": {
         "owner": "numtide",
         "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
+    "uv2nix": {
+      "inputs": {
+        "nixpkgs": [
+          "mkdocs-flake",
+          "nixpkgs"
+        ],
+        "pyproject-nix": [
+          "mkdocs-flake",
+          "pyproject-nix"
+        ]
+      },
+      "locked": {
+        "lastModified": 1747949765,
+        "narHash": "sha256-1v8SFHOwUCvHDXFmQRjHZYawY19nxmtZ7zH/kwAGgj0=",
+        "owner": "pyproject-nix",
+        "repo": "uv2nix",
+        "rev": "ec0502250b48116fd3aa8e1347a2d0254bacd05e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pyproject-nix",
+        "repo": "uv2nix",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -45,7 +45,7 @@
         flake-root = {
           projectRootFile = "flake.nix";
         };
-        documentation.mkdocs-root = ./docs;
+        documentation.mkdocs-root = ./.;
         nix-unit = {
           allowNetwork = true;
           inputs = {

--- a/flake.nix
+++ b/flake.nix
@@ -10,6 +10,7 @@
     mission-control.url = "github:Platonic-Systems/mission-control";
     flake-root.url = "github:srid/flake-root";
     git-hooks-nix.url = "github:cachix/git-hooks.nix";
+    mkdocs-flake.url = "github:applicative-systems/mkdocs-flake";
   };
 
   outputs = flakeInputs @ {
@@ -27,6 +28,7 @@
         flakeInputs.flake-root.flakeModule
         flakeInputs.git-hooks-nix.flakeModule
         flakeInputs.flake-parts.flakeModules.modules
+        flakeInputs.mkdocs-flake.flakeModule
         # Note: ./modules/latex-utils.nix is auto-discovered by flake-parts.modules
         # and published as outputs.modules.flake.latex-utils
       ];
@@ -43,6 +45,7 @@
         flake-root = {
           projectRootFile = "flake.nix";
         };
+        documentation.mkdocs-root = ./docs;
         nix-unit = {
           allowNetwork = true;
           inputs = {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: latex-utils
 repo_url: https://github.com/jmmaloney4/latex-utils
-docs_dir: .
+docs_dir: docs
 nav:
   - Home: index.md
   - User Guide:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,14 @@
+site_name: latex-utils
+repo_url: https://github.com/jmmaloney4/latex-utils
+docs_dir: docs
+nav:
+  - Home: index.md
+  - User Guide:
+      - Development Shells: user/devshells.md
+      - IDE Integration: user/ide-integration.md
+      - TeX Live Integration: user/texlive-integration.md
+      - Library Reference: user/library.md
+      - Unit Testing: user/unit-testing.md
+      - Consumer Flake Example: user/consumer-flake-example.md
+      - Example Module Packages: user/example-module-packages.nix
+      - Comprehensive Example: user/comprehensive-example.nix


### PR DESCRIPTION
## Summary
- integrate mkdocs-flake into flake.nix
- configure documentation root
- add mkdocs configuration and index page
- document build instructions in README

## Testing
- `nix flake check` *(fails: fetching dependencies interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68414263a4b0832b9fd436b4185c446e