### PR TITLE
Adopt shared Nix/GitHub Actions infrastructure stack

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,5 @@
+{
+  extends: [
+    "github>jmmaloney4/toolbox//renovate/all.json"
+  ]
+}

--- a/.github/workflows/adr-management.yml
+++ b/.github/workflows/adr-management.yml
@@ -1,0 +1,21 @@
+name: 📝 adr management
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'docs/internal/decisions/**'
+permissions:
+  contents: write
+  pull-requests: write
+jobs:
+  adr-management:
+    if: github.actor != 'github-actions[bot]'
+    uses: jmmaloney4/toolbox/.github/workflows/adr-management.yml@main
+    with:
+      runs-on: self-hosted
+      repository: ${{ github.repository }}
+      ref: ${{ github.event.pull_request.head.sha }}
+      base_ref: ${{ github.event.pull_request.base.ref }}
+      adr_glob: 'docs/internal/decisions/*.md'
+      pr_number: ${{ github.event.pull_request.number }}
+      pr_url: ${{ github.event.pull_request.html_url }}

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,33 @@
+name: 👀 claude review
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+permissions:
+  contents: read
+  pull-requests: read
+  issues: read
+  id-token: write
+  actions: read
+jobs:
+  claude-review:
+    if: |
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request &&
+       (contains(github.event.comment.body, 'claude review') || contains(github.event.comment.body, 'Claude review') || contains(github.event.comment.body, 'CLAUDE REVIEW')) &&
+       !contains(github.event.comment.body, 'no claude review') &&
+       !contains(github.event.comment.body, 'disable claude review') &&
+       !contains(github.event.comment.body, 'claude review is not needed')) ||
+      (github.event_name == 'pull_request_review_comment' &&
+       (contains(github.event.comment.body, 'claude review') || contains(github.event.comment.body, 'Claude review') || contains(github.event.comment.body, 'CLAUDE REVIEW')) &&
+       !contains(github.event.comment.body, 'no claude review') &&
+       !contains(github.event.comment.body, 'disable claude review') &&
+       !contains(github.event.comment.body, 'claude review is not needed'))
+    uses: jmmaloney4/toolbox/.github/workflows/claude-review.yml@main
+    with:
+      runs-on: self-hosted
+      repository: ${{ github.repository }}
+      ref: ${{ github.ref }}
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,40 @@
+name: 🤖 claude
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+permissions:
+  contents: read
+  pull-requests: read
+  issues: read
+  id-token: write
+  actions: read
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' &&
+       (contains(github.event.comment.body, '@claude') || contains(github.event.comment.body, '@Claude') || contains(github.event.comment.body, '@CLAUDE')) &&
+       !(contains(github.event.comment.body, 'claude review') || contains(github.event.comment.body, 'Claude review') || contains(github.event.comment.body, 'CLAUDE REVIEW'))) ||
+      (github.event_name == 'pull_request_review_comment' &&
+       (contains(github.event.comment.body, '@claude') || contains(github.event.comment.body, '@Claude') || contains(github.event.comment.body, '@CLAUDE')) &&
+       !(contains(github.event.comment.body, 'claude review') || contains(github.event.comment.body, 'Claude review') || contains(github.event.comment.body, 'CLAUDE REVIEW'))) ||
+      (github.event_name == 'pull_request_review' &&
+       (contains(github.event.review.body, '@claude') || contains(github.event.review.body, '@Claude') || contains(github.event.review.body, '@CLAUDE')) &&
+       !(contains(github.event.review.body, 'claude review') || contains(github.event.review.body, 'Claude review') || contains(github.event.review.body, 'CLAUDE REVIEW'))) ||
+      (github.event_name == 'issues' &&
+       ((contains(github.event.issue.body, '@claude') || contains(github.event.issue.body, '@Claude') || contains(github.event.issue.body, '@CLAUDE')) ||
+        (contains(github.event.issue.title, '@claude') || contains(github.event.issue.title, '@Claude') || contains(github.event.issue.title, '@CLAUDE'))) &&
+       !((contains(github.event.issue.body, 'claude review') || contains(github.event.issue.body, 'Claude review') || contains(github.event.issue.body, 'CLAUDE REVIEW')) ||
+         (contains(github.event.issue.title, 'claude review') || contains(github.event.issue.title, 'Claude review') || contains(github.event.issue.title, 'CLAUDE REVIEW'))))
+    uses: jmmaloney4/toolbox/.github/workflows/claude.yml@main
+    with:
+      runs-on: self-hosted
+      repository: ${{ github.repository }}
+      ref: ${{ github.ref }}
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/nix-flake-update.yml
+++ b/.github/workflows/nix-flake-update.yml
@@ -1,0 +1,20 @@
+name: nix flake update
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * 0' # runs weekly on Sunday at 00:00
+jobs:
+  nix-flake-update:
+    runs-on: self-hosted
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+      - name: Update flake.lock
+        uses: DeterminateSystems/update-flake-lock@main
+        with:
+          branch: nix-flake-update
+          commit-msg: nix flake update
+          pr-title: "nix flake update"
+          pr-assignees: jmmaloney4

--- a/.github/workflows/nix-flake-update.yml
+++ b/.github/workflows/nix-flake-update.yml
@@ -3,6 +3,9 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 0 * * 0' # runs weekly on Sunday at 00:00
+permissions:
+  contents: write
+  pull-requests: write
 jobs:
   nix-flake-update:
     runs-on: self-hosted

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,18 @@
+name: '❄️ nix'
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - main
+permissions:
+  contents: read
+  id-token: write
+  packages: write
+jobs:
+  nix:
+    uses: jmmaloney4/toolbox/.github/workflows/nix.yml@main
+    with:
+      runs-on: self-hosted
+      repository: ${{ github.repository }}
+      ref: ${{ github.ref }}

--- a/.github/workflows/project-auto-add.yaml
+++ b/.github/workflows/project-auto-add.yaml
@@ -1,0 +1,42 @@
+name: add new items to project
+on:
+  pull_request:
+    types: [opened]
+  issues:
+    types: [opened]
+jobs:
+  add-to-project:
+    runs-on: self-hosted
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Install GitHub CLI and extension
+        run: |
+          nix shell nixpkgs#gh nixpkgs#jq -c bash -c '
+            gh extension install github/gh-projects
+          '
+      - name: Get item GraphQL ID
+        id: item
+        run: |
+          nix shell nixpkgs#gh nixpkgs#jq -c bash -c '
+            if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+              gh pr view ${{ github.event.pull_request.number }} --json id -q .id > id.txt
+            else
+              gh issue view ${{ github.event.issue.number }} --json id -q .id > id.txt
+            fi
+            echo "id=$(cat id.txt)" >> "$GITHUB_OUTPUT"
+          '
+      - name: Add to GitHub Project
+        run: |
+          nix shell nixpkgs#gh -c bash -c '
+            gh projects item-add \
+              --owner jmmaloney4 \
+              --project-number 4 \
+              --content-id "${{ steps.item.outputs.id }}"
+          '

--- a/.github/workflows/project-auto-add.yaml
+++ b/.github/workflows/project-auto-add.yaml
@@ -1,42 +1,13 @@
-name: add new items to project
+name: 📌 add to project
 on:
   pull_request:
     types: [opened]
   issues:
     types: [opened]
+permissions:
+  contents: read
 jobs:
   add-to-project:
-    runs-on: self-hosted
-    permissions:
-      contents: read
-      issues: write
-      pull-requests: write
-    env:
-      GH_TOKEN: ${{ github.token }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - name: Install GitHub CLI and extension
-        run: |
-          nix shell nixpkgs#gh nixpkgs#jq -c bash -c '
-            gh extension install github/gh-projects
-          '
-      - name: Get item GraphQL ID
-        id: item
-        run: |
-          nix shell nixpkgs#gh nixpkgs#jq -c bash -c '
-            if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-              gh pr view ${{ github.event.pull_request.number }} --json id -q .id > id.txt
-            else
-              gh issue view ${{ github.event.issue.number }} --json id -q .id > id.txt
-            fi
-            echo "id=$(cat id.txt)" >> "$GITHUB_OUTPUT"
-          '
-      - name: Add to GitHub Project
-        run: |
-          nix shell nixpkgs#gh -c bash -c '
-            gh projects item-add \
-              --owner jmmaloney4 \
-              --project-number 4 \
-              --content-id "${{ steps.item.outputs.id }}"
-          '
+    uses: jmmaloney4/toolbox/.github/workflows/add-to-project.yml@main
+    with:
+      runs-on: self-hosted

--- a/docs/internal/AGENT_CHANGELOG.md
+++ b/docs/internal/AGENT_CHANGELOG.md
@@ -1,3 +1,21 @@
+Timestamp: 2026-04-15T05:18:26Z
+Agent: Hermes (glm-5.1 via zai)
+
+**ADR 013: ADOPT SHARED INFRASTRUCTURE STACK**
+
+Created `docs/internal/decisions/013-adopt-shared-infra-stack.md` proposing migration from standalone CI/Nix infrastructure to the shared org stack (jackpkgs flake-parts modules + toolbox reusable GitHub Actions workflows).
+
+Investigated all five sibling repos (garden, jackpkgs, toolbox, zeus, yard) to document the shared patterns and produce a gap analysis. Key changes proposed:
+- Replace garnix.io with toolbox nix.yml reusable workflow
+- Add jackpkgs as flake input, adopt its fmt and pre-commit modules (remove inline treefmt-nix and git-hooks-nix)
+- Add Renovate config inheriting from toolbox presets
+- Phase 2: claude/claude-review, adr-management, nix-flake-update, project-auto-add workflows
+
+Files affected:
+- Added: `docs/internal/decisions/013-adopt-shared-infra-stack.md`
+
+---
+
 Timestamp: 2025-06-22T16:16:00Z
 Agent: Claude 3.5 Sonnet (via Cursor)
 

--- a/docs/internal/decisions/012-emoji-support-via-lualatex.md
+++ b/docs/internal/decisions/012-emoji-support-via-lualatex.md
@@ -1,0 +1,70 @@
+# ADR 012: Emoji Support via LuaLaTeX
+*Date:* 2026-01-08
+*Status:* proposed
+
+## Context
+Users want emoji support in documents built with latex-utils. Current builds are
+Nix-sandboxed and rely on a prebuilt fontconfig cache derived from the TeX
+environment. This has a few constraints:
+- pdfLaTeX does not support Unicode emoji or color emoji fonts.
+- XeLaTeX can render some monochrome emoji but does not reliably handle modern
+  color emoji fonts.
+- Color emoji require OpenType color fonts and shaping support (HarfBuzz), which
+  is only dependable with LuaHBTeX (LuaLaTeX in TeX Live).
+- System fonts are not visible inside Nix builds; fonts must be supplied
+  explicitly to the fontconfig cache for reproducible output.
+
+## Decision
+Adopt a LuaLaTeX-first solution that integrates the `emoji` package and makes
+emoji fonts available through a configurable font list:
+- Keep `lualatex` as the recommended engine for emoji rendering.
+- Document usage of the `emoji` package (and `\setemojifont{...}`) for authors.
+- Add a new option to supply external font derivations (e.g., `noto-fonts-emoji`)
+  so the fontconfig cache includes emoji fonts during builds and in dev shells.
+- Merge module-level and document-level font lists, mirroring existing
+  `extraTexPackages` behavior for consistency.
+
+## Alternatives Considered
+1. **XeLaTeX only** - supports limited monochrome emoji; unreliable for color
+   emoji fonts in TeX Live.
+2. **pdfLaTeX with image substitution** - works but requires manual image
+   management and loses text semantics.
+3. **LuaLaTeX with explicit emoji fonts (chosen)** - aligns with current default
+   engine and provides the best color emoji support in TeX Live.
+
+## Consequences
+- **Pros:**
+  - Reproducible emoji rendering in Nix builds.
+  - Matches the project default engine and avoids per-doc engine switches.
+  - Flexible font selection per project or document.
+- **Cons:**
+  - Requires LuaLaTeX and a compatible color emoji font.
+  - Adds additional build inputs (font packages) and cache cost.
+
+## Technical Details
+- New options (names TBD):
+  - `latex-utils.extraFonts` (module-level list of font derivations)
+  - `latex-utils.documents[].extraFonts` (optional per-document list)
+- Update `lib/mkLatexPdfDocument.nix` to pass `[texEnv] ++ extraFonts` to
+  `lib/mkFontconfigCache.nix`.
+- Update `modules/latex-utils/document-processing.nix` to merge module-level
+  and document-level font lists similarly to `extraTexPackages`.
+- Update `modules/latex-utils/tex-environment.nix` to include extra font
+  derivations in dev shells and set `FONTCONFIG_FILE`/`FONTCONFIG_CACHE_DIR`
+  to the prebuilt cache for consistent font discovery.
+
+## Appendices
+
+### Appendix A: Example LaTeX usage
+```tex
+\usepackage{emoji}
+\setemojifont{Noto Color Emoji}
+Hello \emoji{rocket} \emoji{sparkles}
+```
+
+### Appendix B: Example Nix configuration
+```nix
+latex-utils.extraTexPackages = [ "emoji" ];
+latex-utils.extraFonts = [ pkgs.noto-fonts-emoji ];
+latex-utils.latexmk.engine = "lualatex";
+```

--- a/docs/internal/decisions/013-adopt-shared-infra-stack.md
+++ b/docs/internal/decisions/013-adopt-shared-infra-stack.md
@@ -64,7 +64,7 @@ Migrate latex-utils to the shared infrastructure stack in two phases. Adopt jack
   - Adds `jackpkgs` as an input, increasing flake evaluation closure
   - garnix.io provided multi-arch builds (x86_64-linux, aarch64-linux, aarch64-darwin) out of the box; toolbox nix.yml must be configured to match or accept a subset
   - jackpkgs fmt module enables formatters latex-utils doesn't need (ruff, biome, rustfmt, etc.) -- harmless but adds to closure
-  - Toolbox pin must be manually updated (no Renovate support for workflow `uses:` pins yet in this repo)
+  - Renovate's `github-actions` manager will automatically update workflow `uses:` pins (e.g., `jmmaloney4/toolbox/.github/workflows/nix.yml@main` → a SHA hash) once configured
 
 ## Technical Details
 

--- a/docs/internal/decisions/013-adopt-shared-infra-stack.md
+++ b/docs/internal/decisions/013-adopt-shared-infra-stack.md
@@ -1,0 +1,141 @@
+# ADR 013: Adopt Shared Nix/GitHub Actions Infrastructure Stack
+*Date:* 2026-04-15
+*Status:* proposed
+
+## Context
+
+latex-utils currently operates with a standalone CI and Nix infrastructure:
+
+- **CI:** garnix.io (third-party Nix build service) via `garnix.yaml`
+- **Formatter:** Inline `treefmt-nix` config (alejandra + latexindent) in `flake.nix`
+- **Pre-commit:** Inline `git-hooks-nix` config in `flake.nix`
+- **nix-unit:** Direct input with 14 test suites (no input sanitization)
+- **Flake inputs:** All standalone -- nixpkgs pinned independently, no shared module library
+
+Five other repos in the org (garden, jackpkgs, toolbox, zeus, yard) have converged on a shared infrastructure stack built around `jmmaloney4/jackpkgs` (flake-parts module library) and `jmmaloney4/toolbox` (reusable GitHub Actions workflows). latex-utils is the sole outlier.
+
+The divergence creates maintenance overhead: formatter configs, pre-commit hooks, and CI pipelines must be maintained independently rather than inheriting improvements from the shared modules.
+
+## Decision
+
+Migrate latex-utils to the shared infrastructure stack in two phases. Adopt jackpkgs flake-parts modules for formatting and pre-commit, and replace garnix.io with toolbox-based GitHub Actions workflows.
+
+### Phase 1: Core Infrastructure (required)
+
+1. **Add `jackpkgs` as a flake input** (`github:jmmaloney4/jackpkgs`) and make `nixpkgs` follow `jackpkgs/nixpkgs` for pin consistency.
+2. **Import `jackpkgs.flakeModules.default`** (or select specific modules: fmt, pre-commit). This replaces:
+   - Inline `treefmt-nix` config with `jackpkgs` fmt module (keeps alejandra + latexindent, gains consistent default excludes)
+   - Inline `git-hooks-nix` config with `jackpkgs` pre-commit module
+   - Remove `treefmt-nix` and `git-hooks-nix` as direct inputs (provided transitively through jackpkgs)
+3. **Replace garnix.io with `.github/workflows/nix.yml`** calling `jmmaloney4/toolbox/.github/workflows/nix.yml@<pin>`. Delete `garnix.yaml`.
+4. **Add Renovate config** (`.github/renovate.json5`) inheriting from `jmmaloney4/toolbox//renovate/all.json`.
+
+### Phase 2: CI Enhancements (recommended)
+
+5. **Add `.github/workflows/nix-flake-update.yml`** -- weekly cron creating PRs via DeterminateSystems/update-flake-lock.
+6. **Add `.github/workflows/claude.yml`** and **`claude-review.yml`** -- delegates to toolbox for `@claude` mentions in issues/PRs.
+7. **Add `.github/workflows/adr-management.yml`** -- delegates to toolbox for ADR numbering enforcement on PRs touching `docs/internal/decisions/`.
+8. **Add `.github/workflows/project-auto-add.yaml`** -- auto-adds new issues/PRs to GitHub Project board.
+
+### Not in scope
+
+- **Pulumi:** No deploy targets. This is a Nix library.
+- **Python/Node modules:** No Python or Node.js source in this repo.
+- **Container images:** No nix2container or docker builds needed.
+- **mission-control to just-flake migration:** Optional future cleanup; not blocking.
+- **mkdocs-flake:** Keep as-is; unique to this repo.
+
+## Alternatives Considered
+
+1. **Stay on garnix.io with standalone inputs** -- Minimizes short-term churn but latex-utils remains the only repo outside the shared stack, increasing long-term maintenance burden and divergence.
+2. **Adopt jackpkgs but keep garnix.io** -- Partial adoption. Loses the benefit of toolbox's nix-eval-jobs build matrix and self-hosted runner caching. Inconsistent with other repos.
+3. **Adopt shared stack (chosen)** -- Aligns latex-utils with the org standard. One-time migration cost, then inherits improvements automatically.
+
+## Consequences
+
+- **Pros:**
+  - Single source of truth for formatter/linting config via jackpkgs fmt module
+  - CI runs on self-hosted runners (faster, no garnix queue)
+  - Automatic flake lock updates via Renovate + nix-flake-update bot
+  - ADR numbering enforcement prevents conflicts
+  - AI-assisted review via claude/claude-review workflows
+  - nixpkgs pin stays synchronized with the rest of the org
+- **Cons:**
+  - Adds `jackpkgs` as an input, increasing flake evaluation closure
+  - garnix.io provided multi-arch builds (x86_64-linux, aarch64-linux, aarch64-darwin) out of the box; toolbox nix.yml must be configured to match or accept a subset
+  - jackpkgs fmt module enables formatters latex-utils doesn't need (ruff, biome, rustfmt, etc.) -- harmless but adds to closure
+  - Toolbox pin must be manually updated (no Renovate support for workflow `uses:` pins yet in this repo)
+
+## Technical Details
+
+### File changes (Phase 1)
+
+```
+Modified:
+  flake.nix              -- add jackpkgs input, import modules, remove inline fmt/pre-commit
+  flake.lock             -- regenerated
+
+Added:
+  .github/workflows/nix.yml             -- toolbox nix.yml caller
+  .github/renovate.json5                 -- inheriting toolbox presets
+
+Removed:
+  garnix.yaml                            -- replaced by GitHub Actions
+```
+
+### File changes (Phase 2)
+
+```
+Added:
+  .github/workflows/nix-flake-update.yml
+  .github/workflows/claude.yml
+  .github/workflows/claude-review.yml
+  .github/workflows/adr-management.yml
+  .github/workflows/project-auto-add.yaml
+```
+
+### Inputs to remove from flake.nix
+
+- `treefmt-nix` (provided by jackpkgs)
+- `git-hooks-nix` (provided by jackpkgs)
+
+### Inputs to keep
+
+- `nixpkgs` (following jackpkgs/nixpkgs)
+- `flake-parts`
+- `systems`
+- `nix-unit`
+- `flake-root`
+- `mission-control`
+- `mkdocs-flake`
+- `jackpkgs` (new)
+
+### Reference repos
+
+| Repo | jackpkgs modules used | toolbox workflows used |
+|------|----------------------|----------------------|
+| garden | fmt, checks, python, nodejs, pulumi, quarto, just | nix, pulumi, claude, claude-review, adr-management |
+| jackpkgs | fmt, checks, just, pre-commit, shell, pulumi, quarto, python, nodejs | nix, claude, claude-review, adr-management |
+| toolbox | fmt, checks, nodejs | nix (dogfood), pnpm (dogfood), claude, claude-review, adr-management |
+| zeus | fmt, checks, python, nodejs, pulumi, quarto, just | nix, pulumi, rust, claude, claude-review, adr-management |
+| yard | fmt, checks, python, nodejs, pulumi, just | nix, pulumi, claude, claude-review, adr-management |
+
+## Supersedes / Dependencies
+
+- depends on: `jmmaloney4/jackpkgs` (flake-parts modules)
+- depends on: `jmmaloney4/toolbox` (reusable GitHub Actions workflows)
+
+## Appendices
+
+### Appendix A: Cross-repo Infrastructure Comparison
+
+| Dimension | garden | jackpkgs | toolbox | zeus | yard | latex-utils (current) |
+|-----------|--------|----------|---------|------|------|----------------------|
+| CI provider | GitHub Actions + toolbox | GitHub Actions + toolbox | GitHub Actions (dogfood) | GitHub Actions + toolbox | GitHub Actions + toolbox | garnix.io |
+| nixpkgs source | follows jackpkgs | pinned (nixpkgs#483584) | follows jackpkgs | follows jackpkgs | follows jackpkgs | nixos-unstable (independent) |
+| Formatter module | jackpkgs.fmt | jackpkgs.fmt | jackpkgs.fmt | jackpkgs.fmt | jackpkgs.fmt | inline treefmt-nix |
+| Pre-commit module | jackpkgs.pre-commit | jackpkgs.pre-commit | jackpkgs.pre-commit | jackpkgs.pre-commit | jackpkgs.pre-commit | inline git-hooks-nix |
+| nix-unit | no | yes (30+ tests) | no | no | no | yes (14 tests) |
+| Runner | self-hosted | self-hosted | self-hosted | runs-on SaaS | runs-on SaaS | garnix hosted |
+| Renovate | no | yes | yes (presets) | no | yes (toolbox presets) | no |
+| Flake update bot | yes (weekly) | no | no | no | no | no |

--- a/flake.lock
+++ b/flake.lock
@@ -187,27 +187,6 @@
         "type": "github"
       }
     },
-    "flake-parts_4": {
-      "inputs": {
-        "nixpkgs-lib": [
-          "nix-unit",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1733312601,
-        "narHash": "sha256-4pDvzqnegAfRkPwO3wmwBhVi/Sye1mzps0zHWYnP88c=",
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "rev": "205b12d8b7cd4802fbcb8e8ef6a0f1408781a4f9",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "type": "github"
-      }
-    },
     "flake-root": {
       "locked": {
         "lastModified": 1723604017,
@@ -467,27 +446,6 @@
         "type": "github"
       }
     },
-    "nix-github-actions_3": {
-      "inputs": {
-        "nixpkgs": [
-          "nix-unit",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1731952509,
-        "narHash": "sha256-p4gB3Rhw8R6Ak4eMl8pqjCPOLCZRqaehZxdZ/mbFClM=",
-        "owner": "nix-community",
-        "repo": "nix-github-actions",
-        "rev": "7b5f051df789b6b20d259924d349a9ba3319b226",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "nix-github-actions",
-        "type": "github"
-      }
-    },
     "nix-unit": {
       "inputs": {
         "flake-parts": [
@@ -510,27 +468,6 @@
         "owner": "nix-community",
         "repo": "nix-unit",
         "rev": "1c9ab50554eed0b768f9e5b6f646d63c9673f0f7",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "nix-unit",
-        "type": "github"
-      }
-    },
-    "nix-unit_2": {
-      "inputs": {
-        "flake-parts": "flake-parts_4",
-        "nix-github-actions": "nix-github-actions_3",
-        "nixpkgs": "nixpkgs_3",
-        "treefmt-nix": "treefmt-nix_4"
-      },
-      "locked": {
-        "lastModified": 1745514172,
-        "narHash": "sha256-FV8uIBumYYmqOMEa6WR3lFxs0ocANT7bbawEDg+vWjo=",
-        "owner": "nix-community",
-        "repo": "nix-unit",
-        "rev": "be0d299e89a31e246c5472bf0e1005d4cc1e9e55",
         "type": "github"
       },
       "original": {
@@ -582,22 +519,6 @@
       "original": {
         "owner": "NixOS",
         "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_3": {
-      "locked": {
-        "lastModified": 1733376361,
-        "narHash": "sha256-aLJxoTDDSqB+/3orsulE6/qdlX6MzDLIITLZqdgMpqo=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "929116e316068c7318c54eb4d827f7d9756d5e9c",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -769,12 +690,18 @@
         "jackpkgs": "jackpkgs",
         "mission-control": "mission-control",
         "mkdocs-flake": "mkdocs-flake",
-        "nix-unit": "nix-unit_2",
+        "nix-unit": [
+          "jackpkgs",
+          "nix-unit"
+        ],
         "nixpkgs": [
           "jackpkgs",
           "nixpkgs"
         ],
-        "systems": "systems_6"
+        "systems": [
+          "jackpkgs",
+          "systems"
+        ]
       }
     },
     "rust-analyzer-src": {
@@ -869,21 +796,6 @@
         "type": "github"
       }
     },
-    "systems_6": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
     "treefmt": {
       "inputs": {
         "nixpkgs": [
@@ -963,27 +875,6 @@
         "owner": "numtide",
         "repo": "treefmt-nix",
         "rev": "9ef337e492a5555d8e17a51c911ff1f02635be15",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "treefmt-nix",
-        "type": "github"
-      }
-    },
-    "treefmt-nix_4": {
-      "inputs": {
-        "nixpkgs": [
-          "nix-unit",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1733662930,
-        "narHash": "sha256-9qOp6jNdezzLMxwwXaXZWPXosHbNqno+f7Ii/xftqZ8=",
-        "owner": "numtide",
-        "repo": "treefmt-nix",
-        "rev": "357cda84af1d74626afb7fb3bc12d6957167cda9",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -1,18 +1,129 @@
 {
   "nodes": {
-    "flake-compat": {
-      "flake": false,
+    "blueprint": {
+      "inputs": {
+        "nixpkgs": [
+          "jackpkgs",
+          "llm-agents",
+          "nixpkgs"
+        ],
+        "systems": "systems_2"
+      },
       "locked": {
-        "lastModified": 1696426674,
-        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "lastModified": 1769353768,
+        "narHash": "sha256-zI+7cbMI4wMIR57jMjDSEsVb3grapTnURDxxJPYFIW0=",
+        "owner": "numtide",
+        "repo": "blueprint",
+        "rev": "c7da5c70ad1c9b60b6f5d4f674fbe205d48d8f6c",
         "type": "github"
       },
       "original": {
-        "owner": "edolstra",
+        "owner": "numtide",
+        "repo": "blueprint",
+        "type": "github"
+      }
+    },
+    "bun2nix": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "import-tree": "import-tree",
+        "nixpkgs": [
+          "jackpkgs",
+          "nixpkgs"
+        ],
+        "systems": "systems",
+        "treefmt-nix": "treefmt-nix"
+      },
+      "locked": {
+        "lastModified": 1770895533,
+        "narHash": "sha256-v3QaK9ugy9bN9RXDnjw0i2OifKmz2NnKM82agtqm/UY=",
+        "owner": "nix-community",
+        "repo": "bun2nix",
+        "rev": "c843f477b15f51151f8c6bcc886954699440a6e1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "bun2nix",
+        "type": "github"
+      }
+    },
+    "crane": {
+      "locked": {
+        "lastModified": 1745454774,
+        "narHash": "sha256-oLvmxOnsEKGtwczxp/CwhrfmQUG2ym24OMWowcoRhH8=",
+        "rev": "efd36682371678e2b6da3f108fdb5c613b3ec598",
+        "revCount": 729,
+        "type": "tarball",
+        "url": "https://api.flakehub.com/f/pinned/ipetkov/crane/0.20.3/01966538-0f80-7363-a573-2ba9fd154399/source.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://flakehub.com/f/ipetkov/crane/0.20"
+      }
+    },
+    "fenix": {
+      "inputs": {
+        "nixpkgs": [
+          "jackpkgs",
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": "rust-analyzer-src"
+      },
+      "locked": {
+        "lastModified": 1769670296,
+        "narHash": "sha256-0OzQzsufPwHUTJMAgVf+TXPFG+8x5xrYwz1/M/kI+7o=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "b00052920f71c43987b44c804196c083eb0fa1bf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
+        "owner": "NixOS",
         "repo": "flake-compat",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-iter": {
+      "inputs": {
+        "crane": "crane",
+        "fenix": [
+          "jackpkgs",
+          "fenix"
+        ],
+        "flake-schemas": "flake-schemas",
+        "nixpkgs": [
+          "jackpkgs",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1765984791,
+        "narHash": "sha256-EAyJ8QV67uy+wfyjv3z5U8w9EZUGjJEj/56VOH8AO+k=",
+        "owner": "DeterminateSystems",
+        "repo": "flake-iter",
+        "rev": "87845b1b42b10f329779840584b30e0213e5c956",
+        "type": "github"
+      },
+      "original": {
+        "owner": "DeterminateSystems",
+        "repo": "flake-iter",
         "type": "github"
       }
     },
@@ -21,11 +132,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1748821116,
-        "narHash": "sha256-F82+gS044J1APL0n4hH50GYdPRv/5JWm34oCJYmVKdE=",
+        "lastModified": 1769996383,
+        "narHash": "sha256-AnYjnFWgS49RlqX7LrC4uA+sCCDBj0Ry/WOJ5XWAsa0=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "49f0870db23e8c1ca0b5259734a02cd9e1e371a1",
+        "rev": "57928607ea566b5db3ad13af0e57e921e6b12381",
         "type": "github"
       },
       "original": {
@@ -35,6 +146,27 @@
       }
     },
     "flake-parts_2": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "jackpkgs",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1768135262,
+        "narHash": "sha256-PVvu7OqHBGWN16zSi6tEmPwwHQ4rLPU9Plvs8/1TUBY=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "80daad04eddbbf5a4d883996a73f3f542fa437ac",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-parts_3": {
       "inputs": {
         "nixpkgs-lib": [
           "mkdocs-flake",
@@ -55,7 +187,7 @@
         "type": "github"
       }
     },
-    "flake-parts_3": {
+    "flake-parts_4": {
       "inputs": {
         "nixpkgs-lib": [
           "nix-unit",
@@ -91,9 +223,23 @@
         "type": "github"
       }
     },
+    "flake-schemas": {
+      "locked": {
+        "lastModified": 1721999734,
+        "narHash": "sha256-G5CxYeJVm4lcEtaO87LKzOsVnWeTcHGKbKxNamNWgOw=",
+        "rev": "0a5c42297d870156d9c57d8f99e476b738dcd982",
+        "revCount": 75,
+        "type": "tarball",
+        "url": "https://api.flakehub.com/f/pinned/DeterminateSystems/flake-schemas/0.1.5/0190ef2f-61e0-794b-ba14-e82f225e55e6/source.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://flakehub.com/f/DeterminateSystems/flake-schemas/0.1"
+      }
+    },
     "flake-utils": {
       "inputs": {
-        "systems": "systems"
+        "systems": "systems_4"
       },
       "locked": {
         "lastModified": 1726560853,
@@ -109,44 +255,133 @@
         "type": "github"
       }
     },
-    "git-hooks-nix": {
-      "inputs": {
-        "flake-compat": "flake-compat",
-        "gitignore": "gitignore",
-        "nixpkgs": "nixpkgs"
-      },
-      "locked": {
-        "lastModified": 1747372754,
-        "narHash": "sha256-2Y53NGIX2vxfie1rOW0Qb86vjRZ7ngizoo+bnXU9D9k=",
-        "owner": "cachix",
-        "repo": "git-hooks.nix",
-        "rev": "80479b6ec16fefd9c1db3ea13aeb038c60530f46",
-        "type": "github"
-      },
-      "original": {
-        "owner": "cachix",
-        "repo": "git-hooks.nix",
-        "type": "github"
-      }
-    },
     "gitignore": {
       "inputs": {
         "nixpkgs": [
-          "git-hooks-nix",
+          "jackpkgs",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1709087332,
-        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
+        "lastModified": 1762808025,
+        "narHash": "sha256-XmjITeZNMTQXGhhww6ed/Wacy2KzD6svioyCX7pkUu4=",
         "owner": "hercules-ci",
         "repo": "gitignore.nix",
-        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "rev": "cb5e3fdca1de58ccbc3ef53de65bd372b48f567c",
         "type": "github"
       },
       "original": {
         "owner": "hercules-ci",
         "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "home-manager": {
+      "inputs": {
+        "nixpkgs": [
+          "jackpkgs",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1769723138,
+        "narHash": "sha256-kgkwjs33YfJasADIrHjHcTIDs3wNX0xzJhnUP+oldEw=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "175532b6275b34598a0ceb1aef4b9b4006dd4073",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "type": "github"
+      }
+    },
+    "import-tree": {
+      "locked": {
+        "lastModified": 1763762820,
+        "narHash": "sha256-ZvYKbFib3AEwiNMLsejb/CWs/OL/srFQ8AogkebEPF0=",
+        "owner": "vic",
+        "repo": "import-tree",
+        "rev": "3c23749d8013ec6daa1d7255057590e9ca726646",
+        "type": "github"
+      },
+      "original": {
+        "owner": "vic",
+        "repo": "import-tree",
+        "type": "github"
+      }
+    },
+    "jackpkgs": {
+      "inputs": {
+        "bun2nix": "bun2nix",
+        "fenix": "fenix",
+        "flake-compat": "flake-compat",
+        "flake-iter": "flake-iter",
+        "flake-parts": "flake-parts_2",
+        "flake-root": "flake-root",
+        "gitignore": "gitignore",
+        "home-manager": "home-manager",
+        "just-flake": "just-flake",
+        "llm-agents": "llm-agents",
+        "nix-unit": "nix-unit",
+        "nixpkgs": "nixpkgs",
+        "pre-commit-hooks": "pre-commit-hooks",
+        "pyproject-build-systems": "pyproject-build-systems",
+        "pyproject-nix": "pyproject-nix",
+        "systems": "systems_3",
+        "treefmt": "treefmt",
+        "uv2nix": "uv2nix"
+      },
+      "locked": {
+        "lastModified": 1775589245,
+        "narHash": "sha256-YCeWP9wCdQGu8pHK7StM90rvyFiALQFl9XQASMTZirc=",
+        "owner": "jmmaloney4",
+        "repo": "jackpkgs",
+        "rev": "1af64aefdbd26acf786bd12485863b300fa11b94",
+        "type": "github"
+      },
+      "original": {
+        "owner": "jmmaloney4",
+        "repo": "jackpkgs",
+        "type": "github"
+      }
+    },
+    "just-flake": {
+      "locked": {
+        "lastModified": 1713316411,
+        "narHash": "sha256-NkJfU6H+6vgHkPtZ2ESbZ/h2wnsDQrZvB4vbdUIBx8Q=",
+        "owner": "juspay",
+        "repo": "just-flake",
+        "rev": "0e33952a4bcd16cd54ee3aba8111606c237d4526",
+        "type": "github"
+      },
+      "original": {
+        "owner": "juspay",
+        "repo": "just-flake",
+        "type": "github"
+      }
+    },
+    "llm-agents": {
+      "inputs": {
+        "blueprint": "blueprint",
+        "nixpkgs": [
+          "jackpkgs",
+          "nixpkgs"
+        ],
+        "treefmt-nix": "treefmt-nix_2"
+      },
+      "locked": {
+        "lastModified": 1771427464,
+        "narHash": "sha256-VhAD/KfXc5NudSjzhsiU27asKu99jwrb7TsD2BRpLZs=",
+        "owner": "numtide",
+        "repo": "llm-agents.nix",
+        "rev": "b9565d386f29e6b10cc7c513be3697e7c6694f9c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "llm-agents.nix",
         "type": "github"
       }
     },
@@ -167,12 +402,12 @@
     },
     "mkdocs-flake": {
       "inputs": {
-        "flake-parts": "flake-parts_2",
+        "flake-parts": "flake-parts_3",
         "nixpkgs": "nixpkgs_2",
         "poetry2nix": "poetry2nix",
-        "pyproject-build-systems": "pyproject-build-systems",
-        "pyproject-nix": "pyproject-nix",
-        "uv2nix": "uv2nix"
+        "pyproject-build-systems": "pyproject-build-systems_2",
+        "pyproject-nix": "pyproject-nix_2",
+        "uv2nix": "uv2nix_2"
       },
       "locked": {
         "lastModified": 1748072100,
@@ -189,6 +424,28 @@
       }
     },
     "nix-github-actions": {
+      "inputs": {
+        "nixpkgs": [
+          "jackpkgs",
+          "nix-unit",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1737420293,
+        "narHash": "sha256-F1G5ifvqTpJq7fdkT34e/Jy9VCyzd5XfJ9TO8fHhJWE=",
+        "owner": "nix-community",
+        "repo": "nix-github-actions",
+        "rev": "f4158fa080ef4503c8f4c820967d946c2af31ec9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nix-github-actions",
+        "type": "github"
+      }
+    },
+    "nix-github-actions_2": {
       "inputs": {
         "nixpkgs": [
           "mkdocs-flake",
@@ -210,7 +467,7 @@
         "type": "github"
       }
     },
-    "nix-github-actions_2": {
+    "nix-github-actions_3": {
       "inputs": {
         "nixpkgs": [
           "nix-unit",
@@ -233,10 +490,40 @@
     },
     "nix-unit": {
       "inputs": {
-        "flake-parts": "flake-parts_3",
-        "nix-github-actions": "nix-github-actions_2",
+        "flake-parts": [
+          "jackpkgs",
+          "flake-parts"
+        ],
+        "nix-github-actions": "nix-github-actions",
+        "nixpkgs": [
+          "jackpkgs",
+          "nixpkgs"
+        ],
+        "treefmt-nix": [
+          "jackpkgs",
+          "treefmt"
+        ]
+      },
+      "locked": {
+        "lastModified": 1762774186,
+        "narHash": "sha256-hRADkHjNt41+JUHw2EiSkMaL4owL83g5ZppjYUdF/Dc=",
+        "owner": "nix-community",
+        "repo": "nix-unit",
+        "rev": "1c9ab50554eed0b768f9e5b6f646d63c9673f0f7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nix-unit",
+        "type": "github"
+      }
+    },
+    "nix-unit_2": {
+      "inputs": {
+        "flake-parts": "flake-parts_4",
+        "nix-github-actions": "nix-github-actions_3",
         "nixpkgs": "nixpkgs_3",
-        "treefmt-nix": "treefmt-nix_2"
+        "treefmt-nix": "treefmt-nix_4"
       },
       "locked": {
         "lastModified": 1745514172,
@@ -254,27 +541,27 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1730768919,
-        "narHash": "sha256-8AKquNnnSaJRXZxc5YmF/WfmxiHX6MMZZasRP6RRQkE=",
+        "lastModified": 1774745961,
+        "narHash": "sha256-HUJVrsEpXeRxnUoAqLZA8GJWFHE7dgW4xh/kUjeTgFw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a04d33c0c3f1a59a2c1cb0c6e34cd24500e5a1dc",
+        "rev": "4354a1cb46416add953247cb1b71631026dc62eb",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
+        "rev": "4354a1cb46416add953247cb1b71631026dc62eb",
         "type": "github"
       }
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1748740939,
-        "narHash": "sha256-rQaysilft1aVMwF14xIdGS3sj1yHlI6oKQNBRTF40cc=",
+        "lastModified": 1769909678,
+        "narHash": "sha256-cBEymOf4/o3FD5AZnzC3J9hLbiZ+QDT/KDuyHXVJOpM=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "656a64127e9d791a334452c6b6606d17539476e2",
+        "rev": "72716169fe93074c333e8d0173151350670b824c",
         "type": "github"
       },
       "original": {
@@ -315,48 +602,16 @@
         "type": "github"
       }
     },
-    "nixpkgs_4": {
-      "locked": {
-        "lastModified": 1748693115,
-        "narHash": "sha256-StSrWhklmDuXT93yc3GrTlb0cKSS0agTAxMGjLKAsY8=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "910796cabe436259a29a72e8d3f5e180fc6dfacc",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_5": {
-      "locked": {
-        "lastModified": 1747958103,
-        "narHash": "sha256-qmmFCrfBwSHoWw7cVK4Aj+fns+c54EBP8cGqp/yK410=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "fe51d34885f7b5e3e7b59572796e1bcb427eccb1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "poetry2nix": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "nix-github-actions": "nix-github-actions",
+        "nix-github-actions": "nix-github-actions_2",
         "nixpkgs": [
           "mkdocs-flake",
           "nixpkgs"
         ],
-        "systems": "systems_2",
-        "treefmt-nix": "treefmt-nix"
+        "systems": "systems_5",
+        "treefmt-nix": "treefmt-nix_3"
       },
       "locked": {
         "lastModified": 1743690424,
@@ -372,7 +627,65 @@
         "type": "github"
       }
     },
+    "pre-commit-hooks": {
+      "inputs": {
+        "flake-compat": [
+          "jackpkgs",
+          "flake-compat"
+        ],
+        "gitignore": [
+          "jackpkgs",
+          "gitignore"
+        ],
+        "nixpkgs": [
+          "jackpkgs",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1769069492,
+        "narHash": "sha256-Efs3VUPelRduf3PpfPP2ovEB4CXT7vHf8W+xc49RL/U=",
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "a1ef738813b15cf8ec759bdff5761b027e3e1d23",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "type": "github"
+      }
+    },
     "pyproject-build-systems": {
+      "inputs": {
+        "nixpkgs": [
+          "jackpkgs",
+          "nixpkgs"
+        ],
+        "pyproject-nix": [
+          "jackpkgs",
+          "pyproject-nix"
+        ],
+        "uv2nix": [
+          "jackpkgs",
+          "uv2nix"
+        ]
+      },
+      "locked": {
+        "lastModified": 1763662255,
+        "narHash": "sha256-4bocaOyLa3AfiS8KrWjZQYu+IAta05u3gYZzZ6zXbT0=",
+        "owner": "pyproject-nix",
+        "repo": "build-system-pkgs",
+        "rev": "042904167604c681a090c07eb6967b4dd4dae88c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pyproject-nix",
+        "repo": "build-system-pkgs",
+        "type": "github"
+      }
+    },
+    "pyproject-build-systems_2": {
       "inputs": {
         "nixpkgs": [
           "mkdocs-flake",
@@ -404,6 +717,27 @@
     "pyproject-nix": {
       "inputs": {
         "nixpkgs": [
+          "jackpkgs",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1769116518,
+        "narHash": "sha256-M+etHAj3oI9zr+Cpj5u2kMAddvxcJCmnWRtH/SklYlY=",
+        "owner": "pyproject-nix",
+        "repo": "pyproject.nix",
+        "rev": "ab521eddafb936498f18c86d83e1774a53b1cb8a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pyproject-nix",
+        "repo": "pyproject.nix",
+        "type": "github"
+      }
+    },
+    "pyproject-nix_2": {
+      "inputs": {
+        "nixpkgs": [
           "mkdocs-flake",
           "nixpkgs"
         ]
@@ -424,15 +758,40 @@
     },
     "root": {
       "inputs": {
-        "flake-parts": "flake-parts",
-        "flake-root": "flake-root",
-        "git-hooks-nix": "git-hooks-nix",
+        "flake-parts": [
+          "jackpkgs",
+          "flake-parts"
+        ],
+        "flake-root": [
+          "jackpkgs",
+          "flake-root"
+        ],
+        "jackpkgs": "jackpkgs",
         "mission-control": "mission-control",
         "mkdocs-flake": "mkdocs-flake",
-        "nix-unit": "nix-unit",
-        "nixpkgs": "nixpkgs_4",
-        "systems": "systems_3",
-        "treefmt-nix": "treefmt-nix_3"
+        "nix-unit": "nix-unit_2",
+        "nixpkgs": [
+          "jackpkgs",
+          "nixpkgs"
+        ],
+        "systems": "systems_6"
+      }
+    },
+    "rust-analyzer-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1769526882,
+        "narHash": "sha256-64CZX2vKsfSLKnTCZ0pbc1jPvixWWwuT382g3QHBz5c=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "40cda2f4bd585c1cb99ae4eb025968b8dc2eec42",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
       }
     },
     "systems": {
@@ -480,7 +839,117 @@
         "type": "github"
       }
     },
+    "systems_4": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_5": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_6": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "treefmt": {
+      "inputs": {
+        "nixpkgs": [
+          "jackpkgs",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1769691507,
+        "narHash": "sha256-8aAYwyVzSSwIhP2glDhw/G0i5+wOrren3v6WmxkVonM=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "28b19c5844cc6e2257801d43f2772a4b4c050a1b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
     "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "jackpkgs",
+          "bun2nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1770228511,
+        "narHash": "sha256-wQ6NJSuFqAEmIg2VMnLdCnUc0b7vslUohqqGGD+Fyxk=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "337a4fe074be1042a35086f15481d763b8ddc0e7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
+    "treefmt-nix_2": {
+      "inputs": {
+        "nixpkgs": [
+          "jackpkgs",
+          "llm-agents",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1770228511,
+        "narHash": "sha256-wQ6NJSuFqAEmIg2VMnLdCnUc0b7vslUohqqGGD+Fyxk=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "337a4fe074be1042a35086f15481d763b8ddc0e7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
+    "treefmt-nix_3": {
       "inputs": {
         "nixpkgs": [
           "mkdocs-flake",
@@ -502,7 +971,7 @@
         "type": "github"
       }
     },
-    "treefmt-nix_2": {
+    "treefmt-nix_4": {
       "inputs": {
         "nixpkgs": [
           "nix-unit",
@@ -523,25 +992,32 @@
         "type": "github"
       }
     },
-    "treefmt-nix_3": {
+    "uv2nix": {
       "inputs": {
-        "nixpkgs": "nixpkgs_5"
+        "nixpkgs": [
+          "jackpkgs",
+          "nixpkgs"
+        ],
+        "pyproject-nix": [
+          "jackpkgs",
+          "pyproject-nix"
+        ]
       },
       "locked": {
-        "lastModified": 1748243702,
-        "narHash": "sha256-9YzfeN8CB6SzNPyPm2XjRRqSixDopTapaRsnTpXUEY8=",
-        "owner": "numtide",
-        "repo": "treefmt-nix",
-        "rev": "1f3f7b784643d488ba4bf315638b2b0a4c5fb007",
+        "lastModified": 1769103499,
+        "narHash": "sha256-6U2AQNC1Sa+d7gUDQ58sqF39YVi5AKT9uHZSr+WVWGo=",
+        "owner": "pyproject-nix",
+        "repo": "uv2nix",
+        "rev": "9eeb39b8fdd8352bfc6f1af7eab79f88bd0a6eb3",
         "type": "github"
       },
       "original": {
-        "owner": "numtide",
-        "repo": "treefmt-nix",
+        "owner": "pyproject-nix",
+        "repo": "uv2nix",
         "type": "github"
       }
     },
-    "uv2nix": {
+    "uv2nix_2": {
       "inputs": {
         "nixpkgs": [
           "mkdocs-flake",

--- a/flake.nix
+++ b/flake.nix
@@ -92,11 +92,8 @@
             }
             // (import ./tests/testModuleLevel.nix {inherit pkgs lib;});
         };
-        # treefmt config is now managed by jackpkgs.fmt module
-        # alejandra and latexindent are enabled by default via jackpkgs
-        treefmt.config = {
-          programs.latexindent.enable = true;
-        };
+        # treefmt config is managed by jackpkgs.fmt module
+        # alejandra and latexindent are enabled by default
         jackpkgs.fmt = {
           excludes = [
             "template/**"

--- a/flake.nix
+++ b/flake.nix
@@ -8,8 +8,8 @@
       url = "github:jmmaloney4/jackpkgs";
     };
     flake-parts.follows = "jackpkgs/flake-parts";
-    systems.url = "github:nix-systems/default";
-    nix-unit.url = "github:nix-community/nix-unit";
+    systems.follows = "jackpkgs/systems";
+    nix-unit.follows = "jackpkgs/nix-unit";
     flake-root.follows = "jackpkgs/flake-root";
     mission-control.url = "github:Platonic-Systems/mission-control";
     mkdocs-flake.url = "github:applicative-systems/mkdocs-flake";

--- a/flake.nix
+++ b/flake.nix
@@ -2,20 +2,23 @@
   description = "Easily compile latex documents with nix flakes.";
 
   inputs = {
-    nixpkgs.url = github:NixOS/nixpkgs/nixos-unstable;
-    flake-parts.url = github:hercules-ci/flake-parts;
+    nixpkgs.follows = "jackpkgs/nixpkgs";
+
+    jackpkgs = {
+      url = "github:jmmaloney4/jackpkgs";
+    };
+    flake-parts.follows = "jackpkgs/flake-parts";
     systems.url = "github:nix-systems/default";
-    nix-unit.url = github:nix-community/nix-unit;
-    treefmt-nix.url = "github:numtide/treefmt-nix";
+    nix-unit.url = "github:nix-community/nix-unit";
+    flake-root.follows = "jackpkgs/flake-root";
     mission-control.url = "github:Platonic-Systems/mission-control";
-    flake-root.url = "github:srid/flake-root";
-    git-hooks-nix.url = "github:cachix/git-hooks.nix";
     mkdocs-flake.url = "github:applicative-systems/mkdocs-flake";
   };
 
   outputs = flakeInputs @ {
     flake-parts,
     nix-unit,
+    jackpkgs,
     systems,
     ...
   }:
@@ -23,15 +26,18 @@
       systems = import systems;
       imports = [
         flakeInputs.nix-unit.modules.flake.default
-        flakeInputs.treefmt-nix.flakeModule
         flakeInputs.mission-control.flakeModule
-        flakeInputs.flake-root.flakeModule
-        flakeInputs.git-hooks-nix.flakeModule
         flakeInputs.flake-parts.flakeModules.modules
         flakeInputs.mkdocs-flake.flakeModule
+
+        # jackpkgs modules (all -- unused modules like python/nodejs/pulumi are
+        # no-ops unless explicitly enabled)
+        jackpkgs.flakeModules.default
+
         # Note: ./modules/latex-utils.nix is auto-discovered by flake-parts.modules
         # and published as outputs.modules.flake.latex-utils
       ];
+      jackpkgs.pulumi.enable = false;
       perSystem = {
         config,
         pkgs,
@@ -86,12 +92,16 @@
             }
             // (import ./tests/testModuleLevel.nix {inherit pkgs lib;});
         };
-        treefmt = {
-          config = {
-            package = pkgs.treefmt;
-            programs.alejandra.enable = true;
-            programs.latexindent.enable = true;
-          };
+        # treefmt config is now managed by jackpkgs.fmt module
+        # alejandra and latexindent are enabled by default via jackpkgs
+        treefmt.config = {
+          programs.latexindent.enable = true;
+        };
+        jackpkgs.fmt = {
+          excludes = [
+            "template/**"
+          ];
+          mdformat.validate = false; # LaTeX markdown in docs
         };
         mission-control = {
           scripts = {
@@ -109,15 +119,6 @@
               config.pre-commit.devShell
               config.treefmt.build.devShell
             ];
-          };
-        };
-        pre-commit = {
-          check.enable = true;
-          settings = {
-            hooks.treefmt = {
-              enable = true;
-              package = config.treefmt.build.wrapper;
-            };
           };
         };
       };

--- a/garnix.yaml
+++ b/garnix.yaml
@@ -1,5 +1,0 @@
-builds:
-  include:
-    - '*.x86_64-linux.*'
-    - '*.aarch64-linux.*'
-    - '*.aarch64-darwin.*'


### PR DESCRIPTION
## Summary

Migrates latex-utils to the shared org infrastructure stack documented in ADR 013. Aligns this repo with garden, jackpkgs, toolbox, zeus, and yard.

## Changes

### Nix / Flake
- Add `jackpkgs` as flake input, follow `jackpkgs/nixpkgs` for pin consistency
- Import `jackpkgs.flakeModules.default` (fmt, pre-commit, checks modules)
- Remove inline `treefmt-nix` and `git-hooks-nix` inputs (now via jackpkgs)
- Remove inline treefmt and pre-commit config blocks (now managed by jackpkgs modules)
- Disable `jackpkgs.pulumi` (not needed for this repo)
- Configure `jackpkgs.fmt` excludes for `template/**` and `mdformat.validate = false`

### CI
- Replace garnix.io with `.github/workflows/nix.yml` delegating to `jmmaloney4/toolbox`
- Add `.github/workflows/nix-flake-update.yml` (weekly Sunday cron)
- Add `.github/workflows/claude.yml` and `claude-review.yml` (AI-assisted review)
- Add `.github/workflows/adr-management.yml` (ADR numbering enforcement)
- Add `.github/workflows/project-auto-add.yaml` (auto-add to GitHub Project #4)
- Delete `garnix.yaml`

### Dependencies
- Add `.github/renovate.json5` inheriting from `jmmaloney4/toolbox//renovate/all.json`

## Commits (squash not intended -- merge commit preferred)

| Commit | Description |
|--------|-------------|
| `1eaef79` | ADR 013: adopt shared infrastructure stack |
| `77ddfd4` | Migrate flake to jackpkgs shared infrastructure modules |
| `0433f19` | Replace garnix.io with toolbox nix.yml |
| `76041e1` | Add Renovate config |
| `ff26fc7` | Add weekly nix flake update workflow |
| `f1aa26b` | Add claude and claude-review workflows |
| `279f5cf` | Add adr-management workflow |
| `7daa92e` | Add project-auto-add workflow |

## Verification

- `nix flake check --no-build` passes on aarch64-darwin
- All existing nix-unit test suites (14) intact
- Formatter and pre-commit hooks now managed by jackpkgs modules

## ADR

- `docs/internal/decisions/013-adopt-shared-infra-stack.md`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CI/automation is re-platformed onto reusable workflows and a new shared Nix input set, so misconfiguration could break builds, formatting, or PR automation despite no runtime/library code changes.
> 
> **Overview**
> Migrates repo infrastructure to the org shared stack by adding `jackpkgs` as a flake input, switching `nixpkgs`/`flake-parts`/`systems`/`nix-unit`/`flake-root` to follow it, and delegating formatting/pre-commit settings to `jackpkgs` (removing inline `treefmt-nix`/`git-hooks-nix` usage).
> 
> Replaces garnix (`garnix.yaml` removed) with GitHub Actions workflows that call `jmmaloney4/toolbox` for Nix CI, plus adds automation for weekly `flake.lock` updates, Renovate presets, ADR numbering enforcement, optional Claude/Claude-review triggers, and auto-adding new PRs/issues to a project.
> 
> Adds new ADR docs (`012`, `013`) and records the infra decision in the internal agent changelog.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97a8a2e5a78e746b671e7a90fbde41dee404badf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->