### PR TITLE
rename: toolbox → sector7

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,5 +1,5 @@
 {
   extends: [
-    "github>jmmaloney4/toolbox//renovate/all.json"
+    "github>jmmaloney4/sector7//renovate/all.json"
   ]
 }

--- a/.github/workflows/adr-management.yml
+++ b/.github/workflows/adr-management.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   adr-management:
     if: github.actor != 'github-actions[bot]'
-    uses: jmmaloney4/toolbox/.github/workflows/adr-management.yml@main
+    uses: jmmaloney4/sector7/.github/workflows/adr-management.yml@main
     with:
       runs-on: self-hosted
       repository: ${{ github.repository }}

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -24,7 +24,7 @@ jobs:
        !contains(github.event.comment.body, 'no claude review') &&
        !contains(github.event.comment.body, 'disable claude review') &&
        !contains(github.event.comment.body, 'claude review is not needed'))
-    uses: jmmaloney4/toolbox/.github/workflows/claude-review.yml@main
+    uses: jmmaloney4/sector7/.github/workflows/claude-review.yml@main
     with:
       runs-on: self-hosted
       repository: ${{ github.repository }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -31,7 +31,7 @@ jobs:
         (contains(github.event.issue.title, '@claude') || contains(github.event.issue.title, '@Claude') || contains(github.event.issue.title, '@CLAUDE'))) &&
        !((contains(github.event.issue.body, 'claude review') || contains(github.event.issue.body, 'Claude review') || contains(github.event.issue.body, 'CLAUDE REVIEW')) ||
          (contains(github.event.issue.title, 'claude review') || contains(github.event.issue.title, 'Claude review') || contains(github.event.issue.title, 'CLAUDE REVIEW'))))
-    uses: jmmaloney4/toolbox/.github/workflows/claude.yml@main
+    uses: jmmaloney4/sector7/.github/workflows/claude.yml@main
     with:
       runs-on: self-hosted
       repository: ${{ github.repository }}

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -11,7 +11,7 @@ permissions:
   packages: write
 jobs:
   nix:
-    uses: jmmaloney4/toolbox/.github/workflows/nix.yml@main
+    uses: jmmaloney4/sector7/.github/workflows/nix.yml@main
     with:
       runs-on: self-hosted
       repository: ${{ github.repository }}

--- a/.github/workflows/project-auto-add.yaml
+++ b/.github/workflows/project-auto-add.yaml
@@ -8,6 +8,6 @@ permissions:
   contents: read
 jobs:
   add-to-project:
-    uses: jmmaloney4/toolbox/.github/workflows/add-to-project.yml@main
+    uses: jmmaloney4/sector7/.github/workflows/add-to-project.yml@main
     with:
       runs-on: self-hosted


### PR DESCRIPTION
Renames all `jmmaloney4/toolbox` references to `jmmaloney4/sector7` in workflow files and renovate config.

Ref: ergodicsystems/hq#130

**Changes:**
- `.github/workflows/nix.yml`
- `.github/workflows/claude-review.yml`
- `.github/workflows/claude.yml`
- `.github/workflows/adr-management.yml`
- `.github/workflows/project-auto-add.yaml`
- `.github/renovate.json5`

Doc files deferred to a follow-up PR.