### PR TITLE
chore: update refs for toolbox → sector7 rename

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,5 +1,5 @@
 {
   extends: [
-    "github>jmmaloney4/toolbox//renovate/all.json"
+    "github>jmmaloney4/sector7//renovate/all.json"
   ]
 }

--- a/.github/workflows/adr-management.yml
+++ b/.github/workflows/adr-management.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   adr-management:
     if: github.actor != 'github-actions[bot]'
-    uses: jmmaloney4/toolbox/.github/workflows/adr-management.yml@main
+    uses: jmmaloney4/sector7/.github/workflows/adr-management.yml@main
     with:
       runs-on: self-hosted
       repository: ${{ github.repository }}

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -24,7 +24,7 @@ jobs:
        !contains(github.event.comment.body, 'no claude review') &&
        !contains(github.event.comment.body, 'disable claude review') &&
        !contains(github.event.comment.body, 'claude review is not needed'))
-    uses: jmmaloney4/toolbox/.github/workflows/claude-review.yml@main
+    uses: jmmaloney4/sector7/.github/workflows/claude-review.yml@main
     with:
       runs-on: self-hosted
       repository: ${{ github.repository }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -31,7 +31,7 @@ jobs:
         (contains(github.event.issue.title, '@claude') || contains(github.event.issue.title, '@Claude') || contains(github.event.issue.title, '@CLAUDE'))) &&
        !((contains(github.event.issue.body, 'claude review') || contains(github.event.issue.body, 'Claude review') || contains(github.event.issue.body, 'CLAUDE REVIEW')) ||
          (contains(github.event.issue.title, 'claude review') || contains(github.event.issue.title, 'Claude review') || contains(github.event.issue.title, 'CLAUDE REVIEW'))))
-    uses: jmmaloney4/toolbox/.github/workflows/claude.yml@main
+    uses: jmmaloney4/sector7/.github/workflows/claude.yml@main
     with:
       runs-on: self-hosted
       repository: ${{ github.repository }}

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -11,7 +11,7 @@ permissions:
   packages: write
 jobs:
   nix:
-    uses: jmmaloney4/toolbox/.github/workflows/nix.yml@main
+    uses: jmmaloney4/sector7/.github/workflows/nix.yml@main
     with:
       runs-on: self-hosted
       repository: ${{ github.repository }}

--- a/.github/workflows/project-auto-add.yaml
+++ b/.github/workflows/project-auto-add.yaml
@@ -8,6 +8,6 @@ permissions:
   contents: read
 jobs:
   add-to-project:
-    uses: jmmaloney4/toolbox/.github/workflows/add-to-project.yml@main
+    uses: jmmaloney4/sector7/.github/workflows/add-to-project.yml@main
     with:
       runs-on: self-hosted

--- a/docs/internal/decisions/013-adopt-shared-infra-stack.md
+++ b/docs/internal/decisions/013-adopt-shared-infra-stack.md
@@ -12,7 +12,7 @@ latex-utils currently operates with a standalone CI and Nix infrastructure:
 - **nix-unit:** Direct input with 14 test suites (no input sanitization)
 - **Flake inputs:** All standalone -- nixpkgs pinned independently, no shared module library
 
-Five other repos in the org (garden, jackpkgs, toolbox, zeus, yard) have converged on a shared infrastructure stack built around `jmmaloney4/jackpkgs` (flake-parts module library) and `jmmaloney4/toolbox` (reusable GitHub Actions workflows). latex-utils is the sole outlier.
+Five other repos in the org (garden, jackpkgs, toolbox, zeus, yard) have converged on a shared infrastructure stack built around `jmmaloney4/jackpkgs` (flake-parts module library) and `jmmaloney4/sector7` (reusable GitHub Actions workflows). latex-utils is the sole outlier.
 
 The divergence creates maintenance overhead: formatter configs, pre-commit hooks, and CI pipelines must be maintained independently rather than inheriting improvements from the shared modules.
 
@@ -27,8 +27,8 @@ Migrate latex-utils to the shared infrastructure stack in two phases. Adopt jack
    - Inline `treefmt-nix` config with `jackpkgs` fmt module (keeps alejandra + latexindent, gains consistent default excludes)
    - Inline `git-hooks-nix` config with `jackpkgs` pre-commit module
    - Remove `treefmt-nix` and `git-hooks-nix` as direct inputs (provided transitively through jackpkgs)
-3. **Replace garnix.io with `.github/workflows/nix.yml`** calling `jmmaloney4/toolbox/.github/workflows/nix.yml@<pin>`. Delete `garnix.yaml`.
-4. **Add Renovate config** (`.github/renovate.json5`) inheriting from `jmmaloney4/toolbox//renovate/all.json`.
+3. **Replace garnix.io with `.github/workflows/nix.yml`** calling `jmmaloney4/sector7/.github/workflows/nix.yml@<pin>`. Delete `garnix.yaml`.
+4. **Add Renovate config** (`.github/renovate.json5`) inheriting from `jmmaloney4/sector7//renovate/all.json`.
 
 ### Phase 2: CI Enhancements (recommended)
 
@@ -64,7 +64,7 @@ Migrate latex-utils to the shared infrastructure stack in two phases. Adopt jack
   - Adds `jackpkgs` as an input, increasing flake evaluation closure
   - garnix.io provided multi-arch builds (x86_64-linux, aarch64-linux, aarch64-darwin) out of the box; toolbox nix.yml must be configured to match or accept a subset
   - jackpkgs fmt module enables formatters latex-utils doesn't need (ruff, biome, rustfmt, etc.) -- harmless but adds to closure
-  - Renovate's `github-actions` manager will automatically update workflow `uses:` pins (e.g., `jmmaloney4/toolbox/.github/workflows/nix.yml@main` → a SHA hash) once configured
+  - Renovate's `github-actions` manager will automatically update workflow `uses:` pins (e.g., `jmmaloney4/sector7/.github/workflows/nix.yml@main` → a SHA hash) once configured
 
 ## Technical Details
 
@@ -123,7 +123,7 @@ Added:
 ## Supersedes / Dependencies
 
 - depends on: `jmmaloney4/jackpkgs` (flake-parts modules)
-- depends on: `jmmaloney4/toolbox` (reusable GitHub Actions workflows)
+- depends on: `jmmaloney4/sector7` (reusable GitHub Actions workflows)
 
 ## Appendices
 


### PR DESCRIPTION
The repo `jmmaloney4/toolbox` has been renamed to `jmmaloney4/sector7`. GitHub Actions `uses:` refs do **not** follow redirects, so all references must be updated to avoid 404 errors.

## Changes

Replaced all occurrences of `jmmaloney4/toolbox` with `jmmaloney4/sector7` in:

- `.github/workflows/nix.yml`
- `.github/workflows/claude-review.yml`
- `.github/workflows/claude.yml`
- `.github/workflows/adr-management.yml`
- `.github/workflows/project-auto-add.yaml`
- `.github/renovate.json5`
- `docs/internal/decisions/013-adopt-shared-infra-stack.md`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Low-complexity rename-only change, but it touches all CI/review workflows and Renovate presets, so a wrong `uses:`/preset path would break automation across the repo.
> 
> **Overview**
> Switches all GitHub Actions reusable workflow callers (Nix CI, Claude/Claude-review, ADR management, and project auto-add) to use `jmmaloney4/sector7` instead of `jmmaloney4/toolbox`.
> 
> Updates `.github/renovate.json5` and the ADR `docs/internal/decisions/013-adopt-shared-infra-stack.md` to reference the new `sector7` preset/workflow paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2cb9df55df7534c3f080fd4381b1a19a486efff0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->