### PR TITLE
feat(deploy): scaffold WorkerSite Pulumi stack for docs hosting

### DIFF
--- a/deploy/www/latex-utils-docs/.gitignore
+++ b/deploy/www/latex-utils-docs/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/deploy/www/latex-utils-docs/Pulumi.dev.yaml
+++ b/deploy/www/latex-utils-docs/Pulumi.dev.yaml
@@ -1,4 +1,4 @@
 secretsprovider: gcpkms://projects/jmmaloney4-admin/locations/us-east5/keyRings/pulumi-secrets-ring/cryptoKeys/pulumi-secrets-key
 config:
   latex-utils-docs:environment: dev
-  latex-utils-docs:domain: docs.latex-utils.jmmaloney4.xyz
+  latex-utils-docs:domain: docs-dev.latex-utils.jmmaloney4.xyz

--- a/deploy/www/latex-utils-docs/Pulumi.dev.yaml
+++ b/deploy/www/latex-utils-docs/Pulumi.dev.yaml
@@ -1,0 +1,4 @@
+secretsprovider: gcpkms://projects/jmmaloney4-admin/locations/us-east5/keyRings/pulumi-secrets-ring/cryptoKeys/pulumi-secrets-key
+config:
+  latex-utils-docs:environment: dev
+  latex-utils-docs:domain: docs.latex-utils.jmmaloney4.xyz

--- a/deploy/www/latex-utils-docs/Pulumi.prod.yaml
+++ b/deploy/www/latex-utils-docs/Pulumi.prod.yaml
@@ -1,0 +1,4 @@
+secretsprovider: gcpkms://projects/jmmaloney4-admin/locations/us-east5/keyRings/pulumi-secrets-ring/cryptoKeys/pulumi-secrets-key
+config:
+  latex-utils-docs:environment: prod
+  latex-utils-docs:domain: docs.latex-utils.jmmaloney4.xyz

--- a/deploy/www/latex-utils-docs/Pulumi.yaml
+++ b/deploy/www/latex-utils-docs/Pulumi.yaml
@@ -8,4 +8,3 @@ description: Cloudflare Workers Site deployment for latex-utils documentation
 config:
   latex-utils-docs:accountId: 622586854078fb4b8547f4d2289c15ab
   latex-utils-docs:zoneId: 4481aa2ba837295997c98f84a1ab3066
-  latex-utils-docs:siteDir: ../../../result-docs

--- a/deploy/www/latex-utils-docs/Pulumi.yaml
+++ b/deploy/www/latex-utils-docs/Pulumi.yaml
@@ -1,0 +1,11 @@
+name: latex-utils-docs
+runtime:
+  name: nodejs
+  options:
+    typescript: false
+    nodeargs: "--import tsx/esm"
+description: Cloudflare Workers Site deployment for latex-utils documentation
+config:
+  latex-utils-docs:accountId: 622586854078fb4b8547f4d2289c15ab
+  latex-utils-docs:zoneId: 4481aa2ba837295997c98f84a1ab3066
+  latex-utils-docs:siteDir: ../../../result-docs

--- a/deploy/www/latex-utils-docs/index.ts
+++ b/deploy/www/latex-utils-docs/index.ts
@@ -7,7 +7,6 @@ const accountId = config.require("accountId");
 const zoneId = config.require("zoneId");
 const domain = config.require("domain");
 const environment = config.require("environment");
-const siteDir = config.require("siteDir");
 const r2BucketName =
   config.get("r2BucketName") || `latex-utils-docs-${environment}`;
 

--- a/deploy/www/latex-utils-docs/index.ts
+++ b/deploy/www/latex-utils-docs/index.ts
@@ -1,0 +1,29 @@
+import { WorkerSite } from "@jmmaloney4/sector7/workersite";
+import * as pulumi from "@pulumi/pulumi";
+
+const config = new pulumi.Config("latex-utils-docs");
+
+const accountId = config.require("accountId");
+const zoneId = config.require("zoneId");
+const domain = config.require("domain");
+const environment = config.require("environment");
+const siteDir = config.require("siteDir");
+const r2BucketName =
+  config.get("r2BucketName") || `latex-utils-docs-${environment}`;
+
+// Deploy the MkDocs documentation site as a public Cloudflare Worker Site.
+// No Zero Trust / GitHub identity -- this is open access.
+const site = new WorkerSite("latex-utils-docs", {
+  accountId: accountId,
+  zoneId: zoneId,
+  name: `latex-utils-docs-${environment}`,
+  domains: [domain],
+  r2Bucket: {
+    bucketName: r2BucketName,
+    create: true,
+  },
+  cacheTtlSeconds: 86400, // 1 day
+});
+
+export const boundDomains = site.boundDomains;
+export const workerName = site.workerName;

--- a/deploy/www/latex-utils-docs/package.json
+++ b/deploy/www/latex-utils-docs/package.json
@@ -1,0 +1,21 @@
+{
+	"name": "latex-utils-docs-deploy",
+	"private": true,
+	"version": "0.1.0",
+	"type": "module",
+	"scripts": {
+		"typecheck": "tsc --noEmit",
+		"preview": "pulumi preview",
+		"up": "pulumi up",
+		"destroy": "pulumi destroy"
+	},
+	"dependencies": {
+		"@jmmaloney4/sector7": "github:jmmaloney4/sector7#main&path:/packages/sector7",
+		"@pulumi/cloudflare": "6.12.0",
+		"@pulumi/pulumi": "3.226.0"
+	},
+	"devDependencies": {
+		"@types/node": "22.19.11",
+		"typescript": "5.9.3"
+	}
+}

--- a/deploy/www/latex-utils-docs/package.json
+++ b/deploy/www/latex-utils-docs/package.json
@@ -12,7 +12,8 @@
 	"dependencies": {
 		"@jmmaloney4/sector7": "github:jmmaloney4/sector7#main&path:/packages/sector7",
 		"@pulumi/cloudflare": "6.12.0",
-		"@pulumi/pulumi": "3.226.0"
+		"@pulumi/pulumi": "3.226.0",
+		"tsx": "4.21.0"
 	},
 	"devDependencies": {
 		"@types/node": "22.19.11",

--- a/deploy/www/latex-utils-docs/tsconfig.json
+++ b/deploy/www/latex-utils-docs/tsconfig.json
@@ -1,0 +1,14 @@
+{
+	"compilerOptions": {
+		"target": "esnext",
+		"module": "NodeNext",
+		"moduleResolution": "NodeNext",
+		"strict": true,
+		"verbatimModuleSyntax": true,
+		"erasableSyntaxOnly": true,
+		"noEmit": true,
+		"allowImportingTsExtensions": true,
+		"skipLibCheck": true
+	},
+	"files": ["index.ts"]
+}

--- a/flake.nix
+++ b/flake.nix
@@ -38,10 +38,11 @@
         # and published as outputs.modules.flake.latex-utils
       ];
       jackpkgs = {
-        nodejs = {
-          enable = true;
-          pnpmDepsHash = "";
-        };
+        # Node.js module requires pnpm-lock.yaml + pnpmDepsHash.
+        # Enable after running `pnpm install` in deploy/www/latex-utils-docs/
+        # and setting the hash from the nix build error message.
+        nodejs.enable = false;
+
         pulumi = {
           enable = true;
           backendUrl = "gs://jmmaloney4-pulumi-state";

--- a/flake.nix
+++ b/flake.nix
@@ -37,7 +37,22 @@
         # Note: ./modules/latex-utils.nix is auto-discovered by flake-parts.modules
         # and published as outputs.modules.flake.latex-utils
       ];
-      jackpkgs.pulumi.enable = false;
+      jackpkgs = {
+        nodejs = {
+          enable = true;
+          pnpmDepsHash = "";
+        };
+        pulumi = {
+          enable = true;
+          backendUrl = "gs://jmmaloney4-pulumi-state";
+          secretsProvider =
+            "gcpkms://projects/jmmaloney4-admin/locations/us-east5/keyRings/pulumi-secrets-ring/cryptoKeys/pulumi-secrets-key";
+          stacks = [{
+            path = "deploy/www/latex-utils-docs";
+            stacks = [ "dev" "prod" ];
+          }];
+        };
+      };
       perSystem = {
         config,
         pkgs,
@@ -119,6 +134,7 @@
         jackpkgs.fmt = {
           excludes = [
             "template/**"
+            "deploy/**"
           ];
           mdformat.validate = false; # LaTeX markdown in docs
         };

--- a/flake.nix
+++ b/flake.nix
@@ -46,12 +46,13 @@
         pulumi = {
           enable = true;
           backendUrl = "gs://jmmaloney4-pulumi-state";
-          secretsProvider =
-            "gcpkms://projects/jmmaloney4-admin/locations/us-east5/keyRings/pulumi-secrets-ring/cryptoKeys/pulumi-secrets-key";
-          stacks = [{
-            path = "deploy/www/latex-utils-docs";
-            stacks = [ "dev" "prod" ];
-          }];
+          secretsProvider = "gcpkms://projects/jmmaloney4-admin/locations/us-east5/keyRings/pulumi-secrets-ring/cryptoKeys/pulumi-secrets-key";
+          stacks = [
+            {
+              path = "deploy/www/latex-utils-docs";
+              stacks = ["dev" "prod"];
+            }
+          ];
         };
       };
       perSystem = {


### PR DESCRIPTION
## Summary

Scaffold a Pulumi stack to deploy the MkDocs documentation site as a public Cloudflare Worker Site using the sector7 `WorkerSite` component.

## Changes

**flake.nix**
- Enable `jackpkgs.pulumi` (pulumi CLI, just recipes, ci-pulumi devshell)
- `jackpkgs.nodejs` left disabled until `pnpm-lock.yaml` exists (see post-merge steps)
- Configure Pulumi backend: `gs://jmmaloney4-pulumi-state` (shared with garden)
- Configure secrets provider: GCP KMS (shared with garden)
- Register stack: `deploy/www/latex-utils-docs` with dev/prod environments
- Exclude `deploy/**` from treefmt

**deploy/www/latex-utils-docs/** (new)
- `Pulumi.yaml` — project config (Cloudflare account, zone)
- `Pulumi.dev.yaml` — dev stack: `docs-dev.latex-utils.jmmaloney4.xyz`
- `Pulumi.prod.yaml` — prod stack: `docs.latex-utils.jmmaloney4.xyz`
- `package.json` — depends on `@jmmaloney4/sector7`, `@pulumi/cloudflare`, `@pulumi/pulumi`, `tsx`
- `index.ts` — instantiates `WorkerSite` with public access (no Zero Trust)
- `tsconfig.json` — strict TS with NodeNext modules
- `.gitignore` — excludes `node_modules/`

## Architecture

Follows the same pattern as `garden/deploy/www/theoretical-edge/`:
- sector7 `WorkerSite` provisions R2 bucket + Cloudflare Worker + WorkersCustomDomain
- Public access (no `githubIdentityProviderId`, `githubOrganizations`, or `paths`)
- Static assets served from R2, Worker handles routing

## Domain

- Dev: `docs-dev.latex-utils.jmmaloney4.xyz`
- Prod: `docs.latex-utils.jmmaloney4.xyz`
- Zone: `jmmaloney4.xyz` (`4481aa2ba837295997c98f84a1ab3066`)

## Post-merge steps

1. `pnpm install` in `deploy/www/latex-utils-docs/` to generate `pnpm-lock.yaml`
2. Enable `jackpkgs.nodejs` and set `pnpmDepsHash` from the nix build error message
3. Run `pulumi stack init dev` in the deploy directory
4. Build docs: `nix build .#documentation`
5. Deploy: `just deploy dev`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new Cloudflare/Pulumi infrastructure configuration and enables `jackpkgs.pulumi`, which can affect deployment state, secrets handling, and developer tooling if misconfigured.
> 
> **Overview**
> Adds a new Pulumi project under `deploy/www/latex-utils-docs` to deploy the latex-utils MkDocs site as a **public** Cloudflare Worker Site, including dev/prod stack configs for `docs-dev.latex-utils.jmmaloney4.xyz` and `docs.latex-utils.jmmaloney4.xyz` and a `WorkerSite` definition that provisions an R2-backed site with a 1-day cache TTL.
> 
> Updates `flake.nix` to enable the Pulumi tooling via `jackpkgs.pulumi` (GCS backend + GCP KMS secrets provider) and register the new dev/prod stacks, while excluding `deploy/**` from formatting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 554006dd597087a99c2387bdb855ce7c13efbb98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->