### PR TITLE
ci(nix): wire attic cache into sector7 reusable workflow

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -16,3 +16,9 @@ jobs:
       runs-on: self-hosted
       repository: ${{ github.repository }}
       ref: ${{ github.ref }}
+      binary-cache-url: ${{ vars.ATTIC_CACHE_URL }}
+      binary-cache-public-key: ${{ vars.ATTIC_CACHE_PUBLIC_KEY }}
+      binary-cache-endpoint: ${{ vars.ATTIC_SERVER_URL }}
+      binary-cache-name: ${{ vars.ATTIC_CACHE_NAME }}
+    secrets:
+      BINARY_CACHE_TOKEN: ${{ secrets.ATTIC_CACHE_TOKEN }}

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -21,6 +21,7 @@ jobs:
       binary-cache-endpoint: ${{ vars.ATTIC_SERVER_URL }}
       binary-cache-name: ${{ vars.ATTIC_CACHE_NAME }}
     secrets:
-      # Only forward the push-capable cache token on trusted events so PR runs
-      # can read from the cache but not push to it.
-      BINARY_CACHE_TOKEN: ${{ github.event_name == 'push' && secrets.ATTIC_CACHE_TOKEN || '' }}
+      # Forward the push-capable cache token only on trusted events (push,
+      # workflow_dispatch). PR runs read from the cache via the substituter
+      # but cannot push.
+      BINARY_CACHE_TOKEN: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && secrets.ATTIC_CACHE_TOKEN || '' }}

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -11,7 +11,7 @@ permissions:
   packages: write
 jobs:
   nix:
-    uses: jmmaloney4/sector7/.github/workflows/nix.yml@main
+    uses: jmmaloney4/sector7/.github/workflows/nix.yml@f3b121ecadfc01ec2c49907322dc2b4c24e80a8e # main
     with:
       runs-on: self-hosted
       repository: ${{ github.repository }}
@@ -21,4 +21,6 @@ jobs:
       binary-cache-endpoint: ${{ vars.ATTIC_SERVER_URL }}
       binary-cache-name: ${{ vars.ATTIC_CACHE_NAME }}
     secrets:
-      BINARY_CACHE_TOKEN: ${{ secrets.ATTIC_CACHE_TOKEN }}
+      # Only forward the push-capable cache token on trusted events so PR runs
+      # can read from the cache but not push to it.
+      BINARY_CACHE_TOKEN: ${{ github.event_name == 'push' && secrets.ATTIC_CACHE_TOKEN || '' }}


### PR DESCRIPTION
## Summary

- Pass the \`ATTIC_*\` repo vars and \`ATTIC_CACHE_TOKEN\` secret to \`jmmaloney4/sector7\`'s reusable nix workflow.
- Same wiring pattern as \`jmmaloney4/garden\` and \`cavinsresearch/zeus\`.

## Dependency

Depends on **jmmaloney4/garden#842**, which provisions the \`ATTIC_*\` Actions vars and \`ATTIC_CACHE_TOKEN\` secret on this repo via the \`deploy/services/attic\` Pulumi stack. Until that lands and \`pulumi up\` runs, these references resolve to empty strings and the reusable workflow's cache-related steps are gated off (no-op).

## Test plan

- [ ] Merge jmmaloney4/garden#842 and run \`pulumi up\` on the \`attic\` stack.
- [ ] Confirm \`ATTIC_*\` vars and \`ATTIC_CACHE_TOKEN\` appear in this repo's Actions settings.
- [ ] Trigger this workflow and confirm cache pulls + pushes work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)