### PR TITLE
ci: drop BINARY_CACHE_TOKEN push gate, let PR runs push to cache

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -21,7 +21,4 @@ jobs:
       binary-cache-endpoint: ${{ vars.ATTIC_SERVER_URL }}
       binary-cache-name: ${{ vars.ATTIC_CACHE_NAME }}
     secrets:
-      # Forward the push-capable cache token only on trusted events (push,
-      # workflow_dispatch). PR runs read from the cache via the substituter
-      # but cannot push.
-      BINARY_CACHE_TOKEN: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && secrets.ATTIC_CACHE_TOKEN || '' }}
+      BINARY_CACHE_TOKEN: ${{ secrets.ATTIC_CACHE_TOKEN }}


### PR DESCRIPTION
## Summary

Drop the `event_name == 'push' || event_name == 'workflow_dispatch'` gate on `BINARY_CACHE_TOKEN`. Pass `secrets.ATTIC_CACHE_TOKEN` unconditionally so PR runs can also push to the Attic cache.

## Why

These workflows trigger on `pull_request` (not `pull_request_target`). On `pull_request`, GitHub doesn't pass secrets to fork-PR runs in the first place — `secrets.ATTIC_CACHE_TOKEN` is empty there regardless of any gate. So the push gate only ever restricted **same-repo branch PRs**, which by definition come from authors with write access to this repo. For these private/trusted repos that threat surface is effectively zero, while the cost is real: PR builds can't seed the cache, so the post-merge run on `main` rebuilds the same input-addressed store paths from source.

The sector7 reusable workflows still gate `attic-token` on `!is_fork` internally — that defense-in-depth survives if a caller ever switches to `pull_request_target`.

## Test plan

- [ ] Open a follow-up PR with any nix change and confirm `attic watch-store` runs on the PR build.
- [ ] Confirm the post-merge run on `main` finds the PR-pushed paths in the cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)