### PR TITLE
build(nix): isolate gcloud profile per ADR 027

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -42,6 +42,14 @@
           # No JS/TS test suite in this project — only a Pulumi deploy script.
           vitest.enable = false;
         };
+
+        # Per-project gcloud profile isolation (ADR 027). This repo deploys to
+        # GCP via Pulumi (GCS state + KMS under jmmaloney4-admin), so pin its
+        # gcloud state to ~/.config/gcloud-profiles/jmmaloney4 via CLOUDSDK_CONFIG
+        # to prevent ADC/account cross-talk when switching between repos. No
+        # iamOrg is set here, so the profile must be specified explicitly.
+        gcp.profile = "jmmaloney4";
+
         nodejs = {
           enable = true;
           pnpmDepsHash = "sha256-OWd3e4BBWJBCmZBNz1MWxcpl6GDFElZKAWUsp+eg1rA=";


### PR DESCRIPTION
## Summary

Extends ADR 027 (per-project gcloud profile isolation) to latex-utils, surfaced while auditing the rollout for jmmaloney4/garden#406.

latex-utils deploys to GCP via Pulumi (`backendUrl = gs://jmmaloney4-pulumi-state`, `secretsProvider = gcpkms://…/jmmaloney4-admin`) but had **no** `jackpkgs.gcp` config, so it inherited the ambient gcloud ADC/account and was subject to credential cross-talk when switching between repos.

This sets `jackpkgs.gcp.profile = "jmmaloney4";` inside the existing flake-level `jackpkgs = { }` block. No `iamOrg` is set here, so the profile must be specified explicitly (same situation as garden).

Effect: the devshell exports `CLOUDSDK_CONFIG=~/.config/gcloud-profiles/jmmaloney4` (+ `GOOGLE_APPLICATION_CREDENTIALS`) and the `auth-status` just recipe becomes available — matching garden/yard/zeus.

## Test plan

- `nix eval .#devShells.aarch64-darwin.default.drvPath` → resolves (option valid against the locked jackpkgs).
- `nix derivation show` on the devshell drv contains `gcloud-profiles/jmmaloney4` → confirms the export.
- Post-merge manual validation (per ADR 027): `nix develop` → `echo "$CLOUDSDK_CONFIG"` shows `~/.config/gcloud-profiles/jmmaloney4`, then one-time `just auth` / `just auth-status` before the next Pulumi deploy.

## Risks / notes

- **First shell after upgrade requires a one-time `just auth`** for this profile (expected ADR 027 behavior).
- Tooling run **outside** the devshell/direnv won't inherit `CLOUDSDK_CONFIG` (ADR 027 caveat) — keep Pulumi/auth-sensitive commands inside the managed shell.

## Links

- Related issue: jmmaloney4/garden#406
- ADR: jmmaloney4/jackpkgs `docs/internal/designs/027-per-project-gcloud-profile-isolation.md`