### PR TITLE
ci: bump sector7 reusable workflows to a04c7f39

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -11,7 +11,7 @@ permissions:
   packages: write
 jobs:
   nix:
-    uses: jmmaloney4/sector7/.github/workflows/nix.yml@2e5bb3f84ad97df9eb8c914987047e6ba29ec508 # main
+    uses: jmmaloney4/sector7/.github/workflows/nix.yml@a04c7f391c3e22213438df6e7fe4a980b823525b # main
     with:
       runs-on: self-hosted
       repository: ${{ github.repository }}


### PR DESCRIPTION
Advances the pinned sector7 reusable-workflow SHA to current sector7 `main` (`a04c7f391c3e22213438df6e7fe4a980b823525b`), which includes the nix-setup host-daemon flakes fix (jmmaloney4/sector7#300). Backwards-compatible — interface changes since the old pin are additive/optional only.

Mechanical change: only the pinned hex SHA on the `uses: jmmaloney4/sector7/.github/workflows/nix.yml@<sha> # main` line in `.github/workflows/nix.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)